### PR TITLE
Updates - Add Sitelocation, Add routed_range, cleanup code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,3 +38,14 @@
 
 ### Features
 - Adjusted EBS Disk type from GP2 to GP3
+
+## 0.0.17 (2025-06-27)
+
+### Features
+- Added automatic site_location - site_location is inferred based on AWS Region 
+- Added Routed_Networks functionality - Routed Networks are created in Cato based on input to the module 
+- Cleaned up Variables and moved locals to the locals.tf file 
+- Moved data calls to data.tf file
+- Updated Readme File 
+- Updated Versions to latest cato provider, aws_provider 
+- Removed native_network for site configuration, inferred from lan_subnet via a for_each

--- a/data.tf
+++ b/data.tf
@@ -1,0 +1,14 @@
+data "cato_accountSnapshotSite" "aws-site" {
+  id = cato_socket_site.aws-site.id
+}
+
+## Lookup data from region and VPC
+data "aws_ami" "vSocket" {
+  most_recent = true
+  name_regex  = "VSOCKET_AWS"
+  owners      = ["aws-marketplace"]
+}
+
+data "aws_availability_zones" "available" {
+  state = "available"
+}

--- a/locals.tf
+++ b/locals.tf
@@ -1,0 +1,3 @@
+locals {
+  default_subnet_gateway = cidrhost(var.subnet_range_lan, 1)
+}

--- a/main.tf
+++ b/main.tf
@@ -3,27 +3,25 @@ resource "cato_socket_site" "aws-site" {
   description     = var.site_description
   name            = var.site_name
   native_range = {
-    native_network_range = var.native_network_range
+    native_network_range = var.subnet_range_lan
     local_ip             = var.lan_local_ip
   }
-  site_location = var.site_location
+  site_location = local.cur_site_location
   site_type     = var.site_type
 }
 
-data "cato_accountSnapshotSite" "aws-site" {
-  id = cato_socket_site.aws-site.id
+
+
+resource "cato_network_range" "routedNetworks" {
+  for_each   = var.routed_networks
+  site_id    = cato_socket_site.aws-site.id
+  name       = each.key # The name is the key from the map item.
+  range_type = "Routed"
+  subnet     = each.value # The subnet is the value from the map item.
+  gateway    = local.default_subnet_gateway
+  depends_on = [aws_instance.vSocket]
 }
 
-## Lookup data from region and VPC
-data "aws_ami" "vSocket" {
-  most_recent = true
-  name_regex  = "VSOCKET_AWS"
-  owners      = ["aws-marketplace"]
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-}
 
 ## vSocket Instance
 resource "aws_instance" "vSocket" {
@@ -31,7 +29,7 @@ resource "aws_instance" "vSocket" {
   ami           = data.aws_ami.vSocket.id
   key_name      = var.key_pair
   instance_type = var.instance_type
-  user_data     = base64encode(data.cato_accountSnapshotSite.aws-site.info.sockets[0].serial)
+  user_data_base64     = base64encode(data.cato_accountSnapshotSite.aws-site.info.sockets[0].serial)
   # Network Interfaces
   # MGMTENI
   network_interface {

--- a/site_location_aws.tf
+++ b/site_location_aws.tf
@@ -1,0 +1,108 @@
+
+# Only run this data block if var.site_location is null
+# (Terraform does not support dynamic data blocks, so we use count)
+data "cato_siteLocation" "site_location" {
+  count = local.all_location_fields_null ? 1 : 0
+  filters = concat([
+    {
+      field     = "city"
+      operation = "exact"
+      search    = local.region_to_location[local.locationstr].city
+    },
+    {
+      field     = "country_name"
+      operation = "exact"
+      search    = local.region_to_location[local.locationstr].country
+    }
+    ],
+    local.region_to_location[local.locationstr].state != null ? [
+      {
+        field     = "state_name"
+        operation = "exact"
+        search    = local.region_to_location[local.locationstr].state
+      }
+  ] : [])
+}
+
+locals {
+  ## Check for all site_location inputs to be null
+  all_location_fields_null = (
+    var.site_location.city == null &&
+    var.site_location.country_code == null &&
+    var.site_location.state_code == null &&
+    var.site_location.timezone == null
+  ) ? true : false
+
+  ## If all site_location fields are null, use the data source to fetch the 
+  ## site_location from azure provuder location, else use var.site_location
+  cur_site_location = local.all_location_fields_null ? {
+    country_code = data.cato_siteLocation.site_location[0].locations[0].country_code
+    timezone     = data.cato_siteLocation.site_location[0].locations[0].timezone[0]
+    state_code   = data.cato_siteLocation.site_location[0].locations[0].state_code
+    city         = data.cato_siteLocation.site_location[0].locations[0].city
+  } : var.site_location
+
+  locationstr = lower(replace(var.region, " ", ""))
+  # Manual mapping of Azure regions to their cities and countries
+  # Since Azure doesn't provide city/country in the API, we create our own mapping
+  region_to_location = {
+    # North America - United States
+    "us-east-1"     = { city = "Ashburn", state = "Virginia", country = "United States", timezone = "UTC-5" }
+    "us-east-2"     = { city = "Columbus", state = "Ohio", country = "United States", timezone = "UTC-5" }
+    "us-west-1"     = { city = "San Francisco", state = "California", country = "United States", timezone = "UTC-8" }
+    "us-west-2"     = { city = "Boardman", state = "Oregon", country = "United States", timezone = "UTC-8" }
+    "us-gov-east-1" = { city = "Fairfax", state = "Virginia", country = "United States", timezone = "UTC-5" }
+    "us-gov-west-1" = { city = "Boardman", state = "Oregon", country = "United States", timezone = "UTC-8" }
+
+    # North America - Canada
+    "ca-central-1" = { city = "Montr\u00c3\u00a9al", state = null, country = "Canada", timezone = "UTC-5" }
+    "ca-west-1"    = { city = "Calgary", state = null, country = "Canada", timezone = "UTC-7" }
+
+    # North America - Mexico
+    "mx-central-1" = { city = "Austin", state = "Texas", country = "United States", timezone = "UTC-6" }
+
+    # Europe
+    "eu-central-1" = { city = "Frankfurt (Oder)", state = null, country = "Germany", timezone = "UTC+1" }
+    "eu-central-2" = { city = "Z\u00c3\u00bcrich", state = null, country = "Switzerland", timezone = "UTC+1" }
+    "eu-west-1"    = { city = "Dublin", state = null, country = "Ireland", timezone = "UTC+0" }
+    "eu-west-2"    = { city = "London", state = null, country = "United Kingdom", timezone = "UTC+0" }
+    "eu-west-3"    = { city = "Paris", state = null, country = "France", timezone = "UTC+1" }
+    "eu-north-1"   = { city = "Stockholm", state = null, country = "Sweden", timezone = "UTC+1" }
+    "eu-south-1"   = { city = "Milan", state = null, country = "Italy", timezone = "UTC+1" }
+    "eu-south-2"   = { city = "Madrid", state = null, country = "Spain", timezone = "UTC+1" }
+
+    # Asia Pacific
+    "ap-east-1"      = { city = "Hong Kong", state = null, country = "Hong Kong", timezone = "UTC+8" }
+    "ap-east-2"      = { city = "Taipei", state = null, country = "Taiwan", timezone = "UTC+8" }
+    "ap-south-1"     = { city = "Mumbai", state = "Maharashtra", country = "India", timezone = "UTC+5:30" }
+    "ap-south-2"     = { city = "Chennai", state = "Tamil Nadu", country = "India", timezone = "UTC+5:30" }
+    "ap-northeast-1" = { city = "Tokyo", state = null, country = "Japan", timezone = "UTC+9" }
+    "ap-northeast-2" = { city = "Seoul", state = null, country = "South Korea", timezone = "UTC+9" }
+    "ap-northeast-3" = { city = "Osaka", state = null, country = "Japan", timezone = "UTC+9" }
+    "ap-southeast-1" = { city = "Singapore", state = null, country = "Singapore", timezone = "UTC+8" }
+    "ap-southeast-2" = { city = "Sydney", state = "New South Wales", country = "Australia", timezone = "UTC+10" }
+    "ap-southeast-3" = { city = "Jakarta", state = null, country = "Indonesia", timezone = "UTC+7" }
+    "ap-southeast-4" = { city = "Melbourne", state = "Victoria", country = "Australia", timezone = "UTC+10" }
+    "ap-southeast-5" = { city = "Kuala Lumpur", state = null, country = "Malaysia", timezone = "UTC+8" }
+    "ap-southeast-7" = { city = "Bangkok", state = null, country = "Thailand", timezone = "UTC+7" }
+
+    # Middle East
+    "me-south-1"   = { city = "Manama", state = null, country = "Bahrain", timezone = "UTC+3" }
+    "me-central-1" = { city = "Dubai", state = null, country = "United Arab Emirates", timezone = "UTC+4" }
+    "il-central-1" = { city = "Tel Aviv", state = null, country = "Israel", timezone = "UTC+2" }
+
+    # Africa
+    "af-south-1" = { city = "Cape Town", state = null, country = "South Africa", timezone = "UTC+2" }
+
+    # South America
+    "sa-east-1" = { city = "S\u00c3\u00a3o Paulo", state = "S\u00c3\u00a3o Paulo", country = "Brazil", timezone = "UTC-3" }
+
+    # China (Isolated regions)
+    "cn-north-1"     = { city = "Beijing", state = null, country = "China", timezone = "UTC+8" }
+    "cn-northwest-1" = { city = "Beijing", state = null, country = "China", timezone = "UTC+8" }
+  }
+}
+
+output "site_location" {
+  value = data.cato_siteLocation.site_location
+}

--- a/variables.tf
+++ b/variables.tf
@@ -9,14 +9,6 @@ variable "site_name" {
   description = "Your Cato Site Name Here"
 }
 
-variable "native_network_range" {
-  type        = string
-  description = <<EOT
-  	Choose the unique network range your vpc is configured with for your socket that does not conflict with the rest of your Wide Area Network.
-    The accepted input format is Standard CIDR Notation, e.g. X.X.X.X/X
-	EOT
-}
-
 variable "site_type" {
   description = "The type of the site"
   type        = string
@@ -25,16 +17,6 @@ variable "site_type" {
     error_message = "The site_type variable must be one of 'DATACENTER','BRANCH','CLOUD_DC','HEADQUARTERS'."
   }
   default = "CLOUD_DC"
-}
-
-variable "site_location" {
-  description = "The location of the site, used for timezone and geolocation.  Use the Cato CLI to get the list of locations. []()"
-  type = object({
-    city         = string
-    country_code = string
-    state_code   = string
-    timezone     = string
-  })
 }
 
 ## Virtual Socket Variables
@@ -113,4 +95,50 @@ variable "license_bw" {
   description = "The license bandwidth number for the cato site, specifying bandwidth ONLY applies for pooled licenses.  For a standard site license that is not pooled, leave this value null. Must be a number greater than 0 and an increment of 10."
   type        = string
   default     = null
+}
+
+variable "site_location" {
+  description = "Site location which is used by the Cato Socket to connect to the closest Cato PoP. If not specified, the location will be derived from the Azure region dynamicaly."
+  type = object({
+    city         = string
+    country_code = string
+    state_code   = string
+    timezone     = string
+  })
+  default = {
+    city         = null
+    country_code = null
+    state_code   = null ## Optional - for countries with states
+    timezone     = null
+  }
+}
+
+variable "region" {
+  description = "AWS Region"
+  type        = string
+}
+
+
+variable "routed_networks" {
+  description = <<EOF
+  A map of routed networks to be accessed behind the vSocket site. The key is the network name and the value is the CIDR range.
+  Example: 
+  routed_networks = {
+  "Peered-VNET-1" = "10.100.1.0/24"
+  "On-Prem-Network" = "192.168.50.0/24"
+  "Management-Subnet" = "10.100.2.0/25"
+  }
+  EOF
+  type        = map(string)
+  default     = {} # Default to an empty map instead of null.
+}
+
+
+variable "subnet_range_lan" {
+  type        = string
+  description = <<EOT
+    Choose a range within the VPC to use as the Private/LAN subnet. This subnet will host the target LAN interface of the vSocket so resources in the VPC (or AWS Region) can route to the Cato Cloud.
+    The minimum subnet length to support High Availability is /29.
+    The accepted input format is Standard CIDR Notation, e.g. X.X.X.X/X
+	EOT
 }

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,12 @@ terraform {
   required_providers {
     cato = {
       source = "catonetworks/cato"
+      version = ">= 0.0.27"
+    }
+    aws = { 
+      source = "hashicorp/aws"
+      version = ">= 5.98.00"
     }
   }
-  required_version = ">= 0.13"
+  required_version = ">= 1.5"
 }


### PR DESCRIPTION
## 0.0.17 (2025-06-27)

### Features
- Added automatic site_location - site_location is inferred based on AWS Region 
- Added Routed_Networks functionality - Routed Networks are created in Cato based on input to the module 
- Cleaned up Variables and moved locals to the locals.tf file 
- Moved data calls to data.tf file
- Updated Readme File 
- Updated Versions to latest cato provider, aws_provider 
- Removed native_network for site configuration, inferred from lan_subnet via a for_each